### PR TITLE
[KAN-4] Corrigir taxa do PayrollLoan para renda acima de R$10.000

### DIFF
--- a/src/main/kotlin/application/domain/models/PayrollLoan.kt
+++ b/src/main/kotlin/application/domain/models/PayrollLoan.kt
@@ -16,7 +16,7 @@ class PayrollLoan : LoanRule {
             income.value <= BigDecimal(2000) -> BigDecimal(1.4)
             income.value <= BigDecimal(5000) -> BigDecimal(1.3)
             income.value <= BigDecimal(10000) -> BigDecimal(1.2)
-            else -> BigDecimal(1.1)
+            else -> BigDecimal(0.9)
         }
 
         return Tax(value=taxRateValue)


### PR DESCRIPTION
## Descrição

Corrige a taxa mensal do `PayrollLoan` para clientes com renda acima de R$10.000. O valor estava incorreto (`1.1%`) conforme definido no CHALLENGE, que especifica `0.9% a.m.`.

## Alterações

- `PayrollLoan.kt` linha 19: `BigDecimal(1.1)` → `BigDecimal(0.9)`

## Jira

[KAN-4](https://status-lucas.atlassian.net/browse/KAN-4)

[KAN-4]: https://status-lucas.atlassian.net/browse/KAN-4?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ