### PR TITLE
feat: KAN-11 Implementar fluxo de aprovação e declínio de empréstimo

### DIFF
--- a/src/main/kotlin/application/commands/LoanApproveCommand.kt
+++ b/src/main/kotlin/application/commands/LoanApproveCommand.kt
@@ -1,0 +1,5 @@
+package application.commands
+
+import application.domain.models.LoanId
+
+data class LoanApproveCommand(val id: LoanId) : Command

--- a/src/main/kotlin/application/commands/LoanDeclineCommand.kt
+++ b/src/main/kotlin/application/commands/LoanDeclineCommand.kt
@@ -1,0 +1,5 @@
+package application.commands
+
+import application.domain.models.LoanId
+
+data class LoanDeclineCommand(val id: LoanId) : Command

--- a/src/main/kotlin/application/domain/events/LoanApprovedEvent.kt
+++ b/src/main/kotlin/application/domain/events/LoanApprovedEvent.kt
@@ -1,0 +1,15 @@
+package application.domain.events
+
+import application.domain.models.LoanId
+import application.domain.models.Proposals
+import application.domain.models.Version
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+@SerialName("LoanApprovedEvent")
+data class LoanApprovedEvent(
+    override val loanId: LoanId,
+    override val version: Version,
+    val proposals: Proposals
+) : LoanEvent

--- a/src/main/kotlin/application/domain/events/LoanApprovedEvent.kt
+++ b/src/main/kotlin/application/domain/events/LoanApprovedEvent.kt
@@ -1,7 +1,9 @@
 package application.domain.events
 
+import application.domain.models.Amount
 import application.domain.models.LoanId
 import application.domain.models.Proposals
+import application.domain.models.Tax
 import application.domain.models.Version
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -11,5 +13,7 @@ import kotlinx.serialization.Serializable
 data class LoanApprovedEvent(
     override val loanId: LoanId,
     override val version: Version,
-    val proposals: Proposals
+    val proposals: Proposals,
+    val amount: Amount,
+    val tax: Tax
 ) : LoanEvent

--- a/src/main/kotlin/application/domain/events/LoanDeclinedEvent.kt
+++ b/src/main/kotlin/application/domain/events/LoanDeclinedEvent.kt
@@ -1,0 +1,15 @@
+package application.domain.events
+
+import application.domain.models.LoanId
+import application.domain.models.Proposals
+import application.domain.models.Version
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+@SerialName("LoanDeclinedEvent")
+data class LoanDeclinedEvent(
+    override val loanId: LoanId,
+    override val version: Version,
+    val proposals: Proposals
+) : LoanEvent

--- a/src/main/kotlin/application/domain/models/Status.kt
+++ b/src/main/kotlin/application/domain/models/Status.kt
@@ -4,6 +4,8 @@ enum class Status {
     INITIALIZED,
     AVAILABLE,
     REQUESTED,
+    APPROVED,
+    DECLINED,
     ABANDONED,
     COMPLETED,
     CANCELED,

--- a/src/main/kotlin/application/domain/models/aggregate/ApprovedLoan.kt
+++ b/src/main/kotlin/application/domain/models/aggregate/ApprovedLoan.kt
@@ -1,7 +1,9 @@
 package application.domain.models.aggregate
 
+import application.domain.models.Amount
 import application.domain.models.LoanId
 import application.domain.models.Proposals
+import application.domain.models.Tax
 import application.domain.models.Version
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -11,5 +13,7 @@ import kotlinx.serialization.Serializable
 data class ApprovedLoan(
     override val version: Version,
     override val identity: LoanId,
-    val proposals: Proposals
+    val proposals: Proposals,
+    val amount: Amount,
+    val tax: Tax
 ) : Loan

--- a/src/main/kotlin/application/domain/models/aggregate/ApprovedLoan.kt
+++ b/src/main/kotlin/application/domain/models/aggregate/ApprovedLoan.kt
@@ -1,0 +1,15 @@
+package application.domain.models.aggregate
+
+import application.domain.models.LoanId
+import application.domain.models.Proposals
+import application.domain.models.Version
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+@SerialName("ApprovedLoan")
+data class ApprovedLoan(
+    override val version: Version,
+    override val identity: LoanId,
+    val proposals: Proposals
+) : Loan

--- a/src/main/kotlin/application/domain/models/aggregate/DeclinedLoan.kt
+++ b/src/main/kotlin/application/domain/models/aggregate/DeclinedLoan.kt
@@ -1,0 +1,15 @@
+package application.domain.models.aggregate
+
+import application.domain.models.LoanId
+import application.domain.models.Proposals
+import application.domain.models.Version
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+@SerialName("DeclinedLoan")
+data class DeclinedLoan(
+    override val version: Version,
+    override val identity: LoanId,
+    val proposals: Proposals
+) : Loan

--- a/src/main/kotlin/application/domain/models/aggregate/Loan.kt
+++ b/src/main/kotlin/application/domain/models/aggregate/Loan.kt
@@ -1,5 +1,7 @@
 package application.domain.models.aggregate
 
+import application.domain.events.LoanApprovedEvent
+import application.domain.events.LoanDeclinedEvent
 import application.domain.events.LoanInitializedEvent
 import application.domain.events.LoanProposalsIssuedEvent
 import application.domain.events.LoanRequestedEvent
@@ -25,10 +27,16 @@ sealed interface Loan: AggregateRoot {
             is InitializedLoan -> Status.INITIALIZED
             is ProposalsIssuedLoan -> Status.AVAILABLE
             is RequestedLoan -> Status.REQUESTED
+            is ApprovedLoan -> Status.APPROVED
+            is DeclinedLoan -> Status.DECLINED
             else -> throw RuntimeException("Event without mapped status")
         }
 
     fun issueProposals(): LoanProposalsIssuedEvent = throw IllegalStateTransitionException(status, Status.AVAILABLE)
 
     fun request(proposalId: ProposalId): LoanRequestedEvent = throw IllegalStateTransitionException(status, Status.REQUESTED)
+
+    fun approve(): LoanApprovedEvent = throw IllegalStateTransitionException(status, Status.APPROVED)
+
+    fun decline(): LoanDeclinedEvent = throw IllegalStateTransitionException(status, Status.DECLINED)
 }

--- a/src/main/kotlin/application/domain/models/aggregate/RequestedLoan.kt
+++ b/src/main/kotlin/application/domain/models/aggregate/RequestedLoan.kt
@@ -1,5 +1,7 @@
 package application.domain.models.aggregate
 
+import application.domain.events.LoanApprovedEvent
+import application.domain.events.LoanDeclinedEvent
 import application.domain.models.LoanId
 import application.domain.models.Proposals
 import application.domain.models.Version
@@ -12,4 +14,16 @@ data class RequestedLoan(
     override val version: Version,
     override val identity: LoanId,
     val proposals: Proposals
-) : Loan
+) : Loan {
+    override fun approve(): LoanApprovedEvent = LoanApprovedEvent(
+        loanId = identity,
+        version = version.next(),
+        proposals = proposals
+    )
+
+    override fun decline(): LoanDeclinedEvent = LoanDeclinedEvent(
+        loanId = identity,
+        version = version.next(),
+        proposals = proposals
+    )
+}

--- a/src/main/kotlin/application/domain/models/aggregate/RequestedLoan.kt
+++ b/src/main/kotlin/application/domain/models/aggregate/RequestedLoan.kt
@@ -3,6 +3,7 @@ package application.domain.models.aggregate
 import application.domain.events.LoanApprovedEvent
 import application.domain.events.LoanDeclinedEvent
 import application.domain.models.LoanId
+import application.domain.models.ProposalStatus
 import application.domain.models.Proposals
 import application.domain.models.Version
 import kotlinx.serialization.SerialName
@@ -15,11 +16,18 @@ data class RequestedLoan(
     override val identity: LoanId,
     val proposals: Proposals
 ) : Loan {
-    override fun approve(): LoanApprovedEvent = LoanApprovedEvent(
-        loanId = identity,
-        version = version.next(),
-        proposals = proposals
-    )
+    override fun approve(): LoanApprovedEvent {
+        val accepted = proposals.getByStatus(ProposalStatus.ACCEPTED)
+            ?: throw IllegalStateException("No accepted proposal found for loan $identity")
+
+        return LoanApprovedEvent(
+            loanId = identity,
+            version = version.next(),
+            proposals = proposals,
+            amount = accepted.amount,
+            tax = accepted.tax
+        )
+    }
 
     override fun decline(): LoanDeclinedEvent = LoanDeclinedEvent(
         loanId = identity,

--- a/src/main/kotlin/application/handlers/LoanApproveHandler.kt
+++ b/src/main/kotlin/application/handlers/LoanApproveHandler.kt
@@ -1,0 +1,21 @@
+package application.handlers
+
+import application.commands.LoanApproveCommand
+import application.ports.inbound.LoanApprovePort
+import application.ports.outbound.LoanRepositoryPort
+import jakarta.enterprise.context.ApplicationScoped
+import kotlinx.coroutines.runBlocking
+
+@ApplicationScoped
+class LoanApproveHandler(private val repository: LoanRepositoryPort) :
+    Handler<LoanApproveCommand>,
+    LoanApprovePort {
+    override fun execute(command: LoanApproveCommand) {
+        runBlocking {
+            repository
+                .pull(command.id)
+                ?.approve()
+                ?.let { event -> repository.push(event) }
+        }
+    }
+}

--- a/src/main/kotlin/application/handlers/LoanDeclineHandler.kt
+++ b/src/main/kotlin/application/handlers/LoanDeclineHandler.kt
@@ -1,0 +1,21 @@
+package application.handlers
+
+import application.commands.LoanDeclineCommand
+import application.ports.inbound.LoanDeclinePort
+import application.ports.outbound.LoanRepositoryPort
+import jakarta.enterprise.context.ApplicationScoped
+import kotlinx.coroutines.runBlocking
+
+@ApplicationScoped
+class LoanDeclineHandler(private val repository: LoanRepositoryPort) :
+    Handler<LoanDeclineCommand>,
+    LoanDeclinePort {
+    override fun execute(command: LoanDeclineCommand) {
+        runBlocking {
+            repository
+                .pull(command.id)
+                ?.decline()
+                ?.let { event -> repository.push(event) }
+        }
+    }
+}

--- a/src/main/kotlin/application/ports/inbound/LoanApprovePort.kt
+++ b/src/main/kotlin/application/ports/inbound/LoanApprovePort.kt
@@ -1,0 +1,5 @@
+package application.ports.inbound
+
+import application.commands.LoanApproveCommand
+
+interface LoanApprovePort : UseCase<LoanApproveCommand>

--- a/src/main/kotlin/application/ports/inbound/LoanDeclinePort.kt
+++ b/src/main/kotlin/application/ports/inbound/LoanDeclinePort.kt
@@ -1,0 +1,5 @@
+package application.ports.inbound
+
+import application.commands.LoanDeclineCommand
+
+interface LoanDeclinePort : UseCase<LoanDeclineCommand>

--- a/src/main/kotlin/application/ports/outbound/LoanRepositoryPort.kt
+++ b/src/main/kotlin/application/ports/outbound/LoanRepositoryPort.kt
@@ -1,5 +1,7 @@
 package application.ports.outbound
 
+import application.domain.events.LoanApprovedEvent
+import application.domain.events.LoanDeclinedEvent
 import application.domain.events.LoanInitializedEvent
 import application.domain.events.LoanProposalsIssuedEvent
 import application.domain.events.LoanRequestedEvent
@@ -14,4 +16,8 @@ interface LoanRepositoryPort {
     suspend fun push(event: LoanProposalsIssuedEvent)
 
     suspend fun push(event: LoanRequestedEvent)
+
+    suspend fun push(event: LoanApprovedEvent)
+
+    suspend fun push(event: LoanDeclinedEvent)
 }

--- a/src/main/kotlin/driven/database/AggregateRecoveryFactory.kt
+++ b/src/main/kotlin/driven/database/AggregateRecoveryFactory.kt
@@ -2,6 +2,8 @@ package driven.database
 
 import application.domain.models.Status
 import application.domain.models.aggregate.Loan
+import driven.database.extension.models.aggregate.approvedLoan
+import driven.database.extension.models.aggregate.declinedLoan
 import driven.database.extension.models.aggregate.initializedLoan
 import driven.database.extension.models.aggregate.proposalsIssuedLoan
 import driven.database.extension.models.aggregate.requestedLoan
@@ -15,6 +17,8 @@ class AggregateRecoveryFactory {
                 Status.INITIALIZED -> initializedLoan(loan)
                 Status.AVAILABLE -> proposalsIssuedLoan(loan)
                 Status.REQUESTED -> requestedLoan(loan)
+                Status.APPROVED -> approvedLoan(loan)
+                Status.DECLINED -> declinedLoan(loan)
                 Status.ABANDONED -> TODO()
                 Status.COMPLETED -> TODO()
                 Status.CANCELED -> TODO()

--- a/src/main/kotlin/driven/database/MysqlLoanRepository.kt
+++ b/src/main/kotlin/driven/database/MysqlLoanRepository.kt
@@ -1,5 +1,7 @@
 package driven.database
 
+import application.domain.events.LoanApprovedEvent
+import application.domain.events.LoanDeclinedEvent
 import application.domain.events.LoanInitializedEvent
 import application.domain.events.LoanProposalsIssuedEvent
 import application.domain.events.LoanRequestedEvent
@@ -152,6 +154,70 @@ class MysqlLoanRepository @Inject constructor(
             )
 
             outboxEventDAO.push(outboxDto = outboxEventDto, connection = connection)
+        }
+    }
+
+    override suspend fun push(event: LoanApprovedEvent) {
+        findByVersion(event.loanId, event.version.previous()) ?: throw RuntimeException()
+
+        pool.withTransactionCustom { connection ->
+            val params = Tuple.of(
+                event.status.toString(),
+                event.version.value,
+                Json.encodeToString<Proposals>(event.proposals),
+                event.loanId.value.toString(),
+                event.version.previous().value
+            )
+
+            connection.preparedQuery(UPDATE_AGGREGATE)
+                .execute(params)
+                .await()
+                .requireRowCountGreaterThan(threshold = 0)
+
+            val updatedLoan = pull(loanId = event.loanId, connection = connection)
+
+            outboxEventDAO.push(
+                outboxDto = OutboxDto(
+                    type = event.javaClass.simpleName.removeSuffix("Event"),
+                    payload = Json.encodeToString(event),
+                    identity = event.loanId.value.toString(),
+                    desAggregateType = AGGREGATE_TYPE,
+                    snapshot = Json.encodeToString(updatedLoan)
+                ),
+                connection = connection
+            )
+        }
+    }
+
+    override suspend fun push(event: LoanDeclinedEvent) {
+        findByVersion(event.loanId, event.version.previous()) ?: throw RuntimeException()
+
+        pool.withTransactionCustom { connection ->
+            val params = Tuple.of(
+                event.status.toString(),
+                event.version.value,
+                Json.encodeToString<Proposals>(event.proposals),
+                event.loanId.value.toString(),
+                event.version.previous().value
+            )
+
+            connection.preparedQuery(UPDATE_AGGREGATE)
+                .execute(params)
+                .await()
+                .requireRowCountGreaterThan(threshold = 0)
+
+            val updatedLoan = pull(loanId = event.loanId, connection = connection)
+
+            outboxEventDAO.push(
+                outboxDto = OutboxDto(
+                    type = event.javaClass.simpleName.removeSuffix("Event"),
+                    payload = Json.encodeToString(event),
+                    identity = event.loanId.value.toString(),
+                    desAggregateType = AGGREGATE_TYPE,
+                    snapshot = Json.encodeToString(updatedLoan)
+                ),
+                connection = connection
+            )
         }
     }
 

--- a/src/main/kotlin/driven/database/MysqlLoanRepository.kt
+++ b/src/main/kotlin/driven/database/MysqlLoanRepository.kt
@@ -17,6 +17,7 @@ import driven.database.dml.Loan.Companion.FIND_BY_ID
 import driven.database.dml.Loan.Companion.FIND_BY_VERSION
 import driven.database.dml.Loan.Companion.INSERT_INITIAL_AGGREGATE
 import driven.database.dml.Loan.Companion.UPDATE_AGGREGATE
+import driven.database.dml.Loan.Companion.UPDATE_AGGREGATE_WITH_TERMS
 import driven.database.extension.events.status
 import driven.database.extension.requireRowCountGreaterThan
 import io.vertx.mysqlclient.MySQLPool
@@ -165,11 +166,13 @@ class MysqlLoanRepository @Inject constructor(
                 event.status.toString(),
                 event.version.value,
                 Json.encodeToString<Proposals>(event.proposals),
+                event.amount.value,
+                event.tax.value,
                 event.loanId.value.toString(),
                 event.version.previous().value
             )
 
-            connection.preparedQuery(UPDATE_AGGREGATE)
+            connection.preparedQuery(UPDATE_AGGREGATE_WITH_TERMS)
                 .execute(params)
                 .await()
                 .requireRowCountGreaterThan(threshold = 0)

--- a/src/main/kotlin/driven/database/dml/Loan.kt
+++ b/src/main/kotlin/driven/database/dml/Loan.kt
@@ -3,8 +3,9 @@ package driven.database.dml
 class Loan {
     companion object {
         const val INSERT_INITIAL_AGGREGATE = "INSERT INTO loan (id, customer, status, version) VALUES (?, ?, ?, ?);"
-        const val FIND_BY_ID = "SELECT id, customer, status, version, proposals, created_at, updated_at FROM loan WHERE id = ?;"
-        const val FIND_BY_VERSION = "SELECT id, customer, status, version, proposals, created_at, updated_at FROM loan WHERE id = ? AND version = ?;"
+        const val FIND_BY_ID = "SELECT id, customer, status, version, proposals, amount, tax, created_at, updated_at FROM loan WHERE id = ?;"
+        const val FIND_BY_VERSION = "SELECT id, customer, status, version, proposals, amount, tax, created_at, updated_at FROM loan WHERE id = ? AND version = ?;"
         const val UPDATE_AGGREGATE = "UPDATE loan SET status = ?, version = ?, proposals = ? WHERE id = ? AND version = ?"
+        const val UPDATE_AGGREGATE_WITH_TERMS = "UPDATE loan SET status = ?, version = ?, proposals = ?, amount = ?, tax = ? WHERE id = ? AND version = ?"
     }
 }

--- a/src/main/kotlin/driven/database/extension/events/LoanEventExtension.kt
+++ b/src/main/kotlin/driven/database/extension/events/LoanEventExtension.kt
@@ -1,5 +1,7 @@
 package driven.database.extension.events
 
+import application.domain.events.LoanApprovedEvent
+import application.domain.events.LoanDeclinedEvent
 import application.domain.events.LoanEvent
 import application.domain.events.LoanInitializedEvent
 import application.domain.events.LoanProposalsIssuedEvent
@@ -12,5 +14,7 @@ val LoanEvent.status
             is LoanInitializedEvent -> Status.INITIALIZED
             is LoanProposalsIssuedEvent -> Status.AVAILABLE
             is LoanRequestedEvent -> Status.REQUESTED
+            is LoanApprovedEvent -> Status.APPROVED
+            is LoanDeclinedEvent -> Status.DECLINED
             else -> throw IllegalArgumentException("Unknown LoanEvent type: ${this::class.java}")
         }

--- a/src/main/kotlin/driven/database/extension/models/aggregate/LoanApprovedExtensions.kt
+++ b/src/main/kotlin/driven/database/extension/models/aggregate/LoanApprovedExtensions.kt
@@ -1,0 +1,25 @@
+package driven.database.extension.models.aggregate
+
+import application.domain.exceptions.UnknowLoanException
+import application.domain.models.LoanId
+import application.domain.models.Proposals
+import application.domain.models.UUIDv4
+import application.domain.models.Version
+import application.domain.models.aggregate.ApprovedLoan
+import driven.database.AggregateRecoveryFactory
+import io.vertx.core.json.JsonObject
+import kotlinx.serialization.json.Json
+
+fun AggregateRecoveryFactory.Companion.approvedLoan(loan: JsonObject): ApprovedLoan {
+    val loanId = LoanId(UUIDv4(loan.getString("id")))
+
+    val proposals = loan.getString("proposals")
+        ?.let { Json.decodeFromString<Proposals>(it) }
+        ?: throw UnknowLoanException(loanId = loanId)
+
+    return ApprovedLoan(
+        version = Version(loan.getInteger("version")),
+        identity = loanId,
+        proposals = proposals
+    )
+}

--- a/src/main/kotlin/driven/database/extension/models/aggregate/LoanApprovedExtensions.kt
+++ b/src/main/kotlin/driven/database/extension/models/aggregate/LoanApprovedExtensions.kt
@@ -1,14 +1,17 @@
 package driven.database.extension.models.aggregate
 
 import application.domain.exceptions.UnknowLoanException
+import application.domain.models.Amount
 import application.domain.models.LoanId
 import application.domain.models.Proposals
+import application.domain.models.Tax
 import application.domain.models.UUIDv4
 import application.domain.models.Version
 import application.domain.models.aggregate.ApprovedLoan
 import driven.database.AggregateRecoveryFactory
 import io.vertx.core.json.JsonObject
 import kotlinx.serialization.json.Json
+import java.math.BigDecimal
 
 fun AggregateRecoveryFactory.Companion.approvedLoan(loan: JsonObject): ApprovedLoan {
     val loanId = LoanId(UUIDv4(loan.getString("id")))
@@ -17,9 +20,19 @@ fun AggregateRecoveryFactory.Companion.approvedLoan(loan: JsonObject): ApprovedL
         ?.let { Json.decodeFromString<Proposals>(it) }
         ?: throw UnknowLoanException(loanId = loanId)
 
+    val amount = loan.getDouble("amount")
+        ?.let { Amount(BigDecimal.valueOf(it)) }
+        ?: throw UnknowLoanException(loanId = loanId)
+
+    val tax = loan.getDouble("tax")
+        ?.let { Tax(BigDecimal.valueOf(it)) }
+        ?: throw UnknowLoanException(loanId = loanId)
+
     return ApprovedLoan(
         version = Version(loan.getInteger("version")),
         identity = loanId,
-        proposals = proposals
+        proposals = proposals,
+        amount = amount,
+        tax = tax
     )
 }

--- a/src/main/kotlin/driven/database/extension/models/aggregate/LoanDeclinedExtensions.kt
+++ b/src/main/kotlin/driven/database/extension/models/aggregate/LoanDeclinedExtensions.kt
@@ -1,0 +1,25 @@
+package driven.database.extension.models.aggregate
+
+import application.domain.exceptions.UnknowLoanException
+import application.domain.models.LoanId
+import application.domain.models.Proposals
+import application.domain.models.UUIDv4
+import application.domain.models.Version
+import application.domain.models.aggregate.DeclinedLoan
+import driven.database.AggregateRecoveryFactory
+import io.vertx.core.json.JsonObject
+import kotlinx.serialization.json.Json
+
+fun AggregateRecoveryFactory.Companion.declinedLoan(loan: JsonObject): DeclinedLoan {
+    val loanId = LoanId(UUIDv4(loan.getString("id")))
+
+    val proposals = loan.getString("proposals")
+        ?.let { Json.decodeFromString<Proposals>(it) }
+        ?: throw UnknowLoanException(loanId = loanId)
+
+    return DeclinedLoan(
+        version = Version(loan.getInteger("version")),
+        identity = loanId,
+        proposals = proposals
+    )
+}

--- a/src/main/kotlin/driver/http/RequestInterceptor.kt
+++ b/src/main/kotlin/driver/http/RequestInterceptor.kt
@@ -20,7 +20,7 @@ class RequestInterceptor @Inject constructor(
         requestStream?.use { it.copyTo(buffer) }
         val requestData = buffer.toByteArray()
 
-        if (request?.method == "POST") {
+        if (request?.method == "POST" && requestData.isNotEmpty()) {
             val data = mapper.readValue(requestData, ObjectNode::class.java)
 
             log.info(

--- a/src/main/kotlin/driver/http/approve/LoanApproveAction.kt
+++ b/src/main/kotlin/driver/http/approve/LoanApproveAction.kt
@@ -1,0 +1,24 @@
+package driver.http.approve
+
+import application.commands.LoanApproveCommand
+import application.domain.models.LoanId
+import application.domain.models.UUIDv4
+import application.ports.inbound.LoanApprovePort
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import jakarta.ws.rs.core.Response.Status.CREATED
+
+@Path("/loans")
+class LoanApproveAction(private val useCase: LoanApprovePort) {
+    @POST
+    @Path("/{id}/approve")
+    @Produces(MediaType.APPLICATION_JSON)
+    fun approve(@PathParam("id") id: String): Response {
+        useCase.execute(LoanApproveCommand(LoanId(UUIDv4(id))))
+        return Response.status(CREATED).build()
+    }
+}

--- a/src/main/kotlin/driver/http/decline/LoanDeclineAction.kt
+++ b/src/main/kotlin/driver/http/decline/LoanDeclineAction.kt
@@ -1,0 +1,24 @@
+package driver.http.decline
+
+import application.commands.LoanDeclineCommand
+import application.domain.models.LoanId
+import application.domain.models.UUIDv4
+import application.ports.inbound.LoanDeclinePort
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import jakarta.ws.rs.core.Response.Status.CREATED
+
+@Path("/loans")
+class LoanDeclineAction(private val useCase: LoanDeclinePort) {
+    @POST
+    @Path("/{id}/decline")
+    @Produces(MediaType.APPLICATION_JSON)
+    fun decline(@PathParam("id") id: String): Response {
+        useCase.execute(LoanDeclineCommand(LoanId(UUIDv4(id))))
+        return Response.status(CREATED).build()
+    }
+}


### PR DESCRIPTION
## Summary
- Implementa transições `REQUESTED → APPROVED` e `REQUESTED → DECLINED` seguindo o padrão existente do projeto
- Cada fluxo tem seu próprio Command, Port, Handler, aggregate, extensões de banco e endpoint HTTP

## Artefatos criados
| Camada | Approve | Decline |
|---|---|---|
| Event | `LoanApprovedEvent` | `LoanDeclinedEvent` |
| Command | `LoanApproveCommand` | `LoanDeclineCommand` |
| Port | `LoanApprovePort` | `LoanDeclinePort` |
| Handler | `LoanApproveHandler` | `LoanDeclineHandler` |
| Aggregate | `ApprovedLoan` | `DeclinedLoan` |
| DB Extensions | `LoanApprovedExtensions` | `LoanDeclinedExtensions` |
| HTTP | `POST /loans/{id}/approve` | `POST /loans/{id}/decline` |

## Artefatos modificados
- `Status` — adicionado `APPROVED` e `DECLINED`
- `Loan` (sealed interface) — expõe `approve()` e `decline()` com `IllegalStateTransitionException` por padrão
- `RequestedLoan` — implementa `approve()` e `decline()`
- `LoanRepositoryPort` — overloads `push(LoanApprovedEvent)` e `push(LoanDeclinedEvent)`
- `MysqlLoanRepository` — implementações dos dois novos push
- `LoanEventExtension` — mapeamento de status para os novos eventos
- `AggregateRecoveryFactory` — suporte a `APPROVED` e `DECLINED`

## Test plan
- [ ] `POST /loans/{id}/approve` retorna `201` para loan no estado `REQUESTED`
- [ ] `POST /loans/{id}/decline` retorna `201` para loan no estado `REQUESTED`
- [ ] Loan persiste com status `APPROVED` / `DECLINED` no banco
- [ ] Eventos `LoanApproved` e `LoanDeclined` são gravados no outbox
- [ ] Chamar `approve()` ou `decline()` em estado inválido lança `IllegalStateTransitionException`

Closes KAN-11

🤖 Generated with [Claude Code](https://claude.com/claude-code)